### PR TITLE
External bksy links pass 2

### DIFF
--- a/content/posts/dont-over-use-state/index.mdx
+++ b/content/posts/dont-over-use-state/index.mdx
@@ -163,7 +163,7 @@ So I'd like to postulate the following:
 
 <p style="padding-left: 3rem; margin-top: -1rem">— TkDodo</p>
 
-This is loosely based on what [@sophiebits](https://twitter.com/sophiebits) posted recently on twitter:
+This is loosely based on what [@sophiebits](https://bsky.app/profile/sophiebits.com) posted recently on twitter:
 
 <Tweet
   name="ms. sophie bites"

--- a/content/posts/refs-events-and-escape-hatches/index.mdx
+++ b/content/posts/refs-events-and-escape-hatches/index.mdx
@@ -197,7 +197,7 @@ export const useDebouncedState = (callback, delay) => {
 }
 ```
 
-This looks pretty clean to me, and if you want to have a user-land implementation of _useEvent_ right now, have a look at this implementation by [Diego Haz](https://twitter.com/diegohaz):
+This looks pretty clean to me, and if you want to have a user-land implementation of _useEvent_ right now, have a look at this implementation by [Diego Haz](https://bsky.app/profile/haz.dev):
 
 <Tweet
   name="Haz"

--- a/content/posts/the-query-options-api/index.mdx
+++ b/content/posts/the-query-options-api/index.mdx
@@ -76,8 +76,10 @@ So why did we do it?
 
 First of all, having all those overloads is a chore for maintainers, and it's also not clear for users. Why can I call the same function in multiple ways - is one better than the other? So, streamlining the API, thus making it easier for new starters to understand it, was one goal. "Always pass one object" is as simple and extensible as it gets.
 
-But also, it turns out that one object to rule them all is simply a very good abstraction for when you want to share query options between different functions. I discovered this "by accident" when I wrote the [React Query meets React Router](react-query-meets-react-router) article, where want to share query options between prefetching and our `useQuery` call. Now usually, you could just write custom hooks as your primary way to re-use queries. But that doesn't work when imperative function calls like `prefetching` are involved. So I came up with something, and [Alex](https://twitter.com/ralex1993) noted this as a good pattern:
+But also, it turns out that one object to rule them all is simply a very good abstraction for when you want to share query options between different functions. I discovered this "by accident" when I wrote the [React Query meets React Router](react-query-meets-react-router) article, where want to share query options between prefetching and our `useQuery` call. Now usually, you could just write custom hooks as your primary way to re-use queries. But that doesn't work when imperative function calls like `prefetching` are involved. So I came up with something, and [Alex](https://bsky.app/profile/ralexanderson‍.com) noted this as a good pattern:
 
+
+{/* NOTE: The tweet id leads to Alex's now protected X account */}
 <Tweet
   name="R. Alex Anderson 🚀"
   handle="ralex1993"


### PR DESCRIPTION
This is a continuation of https://github.com/TkDodo/blog/pull/320

In this case it's slightly more awkward. In this case, as before:
- The person has an active [BlueSky](https://bsky.app/) account
- The person has declared publicly that they are using BlueSky primarily over X/Twitter

But the links in this case ARE associated with a direct link to X via the `Tweet` component in same post as the link. In the case of R. Alex it's actually a dead link as the account is protected.

- Haz‬
	- https://twitter.com/diegohaz -> https://bsky.app/profile/haz.dev
	- https://x.com/diegohaz/status/1854318091305394663

- R. Alex Anderson
	- https://twitter.com/ralex1993 -> [https://bsky.app/profile/ralexanderson‍.com](https://bsky.app/profile/ralexanderson.com)
	- x account set to protected with bsky handle in bio
	- bsky account is active
	- https://bsky.app/profile/ralexanderson.com/post/3l7xwzrabdq2u

- Sophie Alpert
	- https://twitter.com/sophiebits -> https://bsky.app/profile/sophiebits.com
	- bio states "(find me on bl\*\*sky)"
